### PR TITLE
Testing with 'findCommand' and line breaks on readme titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-#Prompt [![Build Status](https://travis-ci.org/go-prompt/prompt.svg?branch=master)](https://travis-ci.org/go-prompt/prompt) [![Coverage Status](https://coveralls.io/repos/go-prompt/prompt/badge.svg)](https://coveralls.io/r/go-prompt/prompt) [![GoDoc](https://godoc.org/github.com/go-prompt/prompt?status.svg)](http://godoc.org/github.com/go-prompt/prompt)
+# Prompt
+
+[![Build Status](https://travis-ci.org/go-prompt/prompt.svg?branch=master)](https://travis-ci.org/go-prompt/prompt) [![Coverage Status](https://coveralls.io/repos/go-prompt/prompt/badge.svg)](https://coveralls.io/r/go-prompt/prompt) [![GoDoc](https://godoc.org/github.com/go-prompt/prompt?status.svg)](http://godoc.org/github.com/go-prompt/prompt)
 
 This Go package provides a dead simple 'terminal-prompt-like' for your application.
 
 
-#Install
+## Install
 There is no extra dependencies, just a [Go environment](http://golang.org/doc/install) is needed. Then:
 ~~~
 $ go get gopkg.in/prompt.v1
 ~~~
 
-#Use
+## Use
 Here you can see an example about how to add a custom command.
 ~~~ go
 package main
@@ -38,5 +40,5 @@ func main() {
 
 This example will show a _terminal-prompt-shell-like_, where you can try your custom command '**ping**'. Or just type '**quit**' to close it. For a list of commands type '**help**'. You can see this in action **[here](https://asciinema.org/a/11556)**.
 
-#TODO
+## TODO
 - [ ] a wrapper for _exec.Command_ (from _os_ standard library).

--- a/command_test.go
+++ b/command_test.go
@@ -6,38 +6,31 @@ import (
 
 func TestAdd(t *testing.T) {
 
-	my_cmd := Command{
+	myCmd := Command{
 		"ping",
 		"just a test",
 		func(args []string) {},
 	}
 
-	Add(my_cmd)
+	Add(myCmd)
 
-	if commands.Len() != 1 {
-		t.Error("The command wasn't added")
-	} else if commands[0].Cmd != "ping" {
+	cmd := findCommand(myCmd.Cmd)
+	if cmd.Action == nil {
 		t.Error("Command not found")
-	} else {
-		// removes command added
-		commands = commands[:commands.Len()-1]
 	}
 }
 
 func TestAddCommand(t *testing.T) {
 
+	cmdName := "foo"
 	AddCommand(
-		"foo",
+		cmdName,
 		"another test",
 		func(args []string) {},
 	)
 
-	if commands.Len() != 1 {
-		t.Error("The command wasn't added")
-	} else if commands[0].Cmd != "foo" {
+	cmd := findCommand(cmdName)
+	if cmd.Action == nil {
 		t.Error("Command not found")
-	} else {
-		// removes command added
-		commands = commands[:commands.Len()-1]
 	}
 }

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -14,7 +14,11 @@ func TestStart(t *testing.T) {
 
 	if commands.Len() == 0 {
 		t.Error("No command found")
-	} else if commands[0].Cmd != "gc" {
+	}
+
+	gcCmdName := "gc"
+	cmd := findCommand(gcCmdName)
+	if cmd.Cmd != gcCmdName {
 		t.Errorf("GC command not found but '%s'\n", commands[0].Cmd)
 	}
 }


### PR DESCRIPTION
- Tests: using 'findCommand' to discover the added commands.
- Appropriated markdown line breaks on readme titles.